### PR TITLE
Added DHTPin 12 as an option in the Arduino sketch. The option is com…

### DIFF
--- a/NodeMCU-Home-Automation-Sensor.ino
+++ b/NodeMCU-Home-Automation-Sensor.ino
@@ -39,7 +39,8 @@ float hum_offset = 14.9;
 
 /**************************************************/
 
-#define DHTPIN 4      // (D2) what digital pin we're connected to
+#define DHTPIN 4      // (D2) what digital pin we're connected to (NodeMCU Breakout Board v1.1 or older)
+//#define DHTPIN 12      // (D6) what digital pin we're connected to (NodeMCU Breakout Board v1.2)
 #define MOTIONPIN 5   // (D1) what digital pin the motion sensor is connected to
 #define PRESSPIN A0    // (A0) what analog pin the pressure sensor is connected to
 


### PR DESCRIPTION
Added _DHTPin 12_ as an option in the Arduino sketch. The option is commented out and specifies that this is the pin to be used with the NodeMCU Breakout board version 1.2. Additionally, the previous code using _DHTPIN 4_ has a new comment explaining that this is to be used with the Original NodeMCU Breakout Board (versions 1.1 and earlier).